### PR TITLE
role validations for Employee module

### DIFF
--- a/include/globalControlLinks.php
+++ b/include/globalControlLinks.php
@@ -63,12 +63,11 @@ $global_control_links['employees'] = array(
 'linkinfo' => array($app_strings['LBL_EMPLOYEES']=> 'index.php?module=Employees&action=index'),
 'submenu' => ''
 );
-if (
-        is_admin($current_user)
-
-        ) {
-    $global_control_links['admin'] = array(
-
+if (!ACLController::checkAccess('Employees', 'view') ) {
+    unset($global_control_links['employees']);
+}
+if (is_admin($current_user)) {
+$global_control_links['admin'] = array(
 'linkinfo' => array($app_strings['LBL_ADMIN'] => 'index.php?module=Administration&action=index'),
 'submenu' => ''
 );

--- a/modules/Employees/Menu.php
+++ b/modules/Employees/Menu.php
@@ -56,5 +56,7 @@ if (empty($_REQUEST['record'])) {
 if (is_admin($current_user)) {
     $module_menu[] = array("index.php?module=Employees&action=EditView&return_module=Employees&return_action=DetailView", $mod_strings['LNK_NEW_EMPLOYEE'],"Create");
 }
-    
-$module_menu[] = array("index.php?module=Employees&action=index&return_module=Employees&return_action=DetailView", $mod_strings['LNK_EMPLOYEE_LIST'],"List");
+
+if (is_admin($current_user)) {    
+    $module_menu[] = array("index.php?module=Employees&action=index&return_module=Employees&return_action=DetailView", $mod_strings['LNK_EMPLOYEE_LIST'],"List");
+}

--- a/modules/Employees/views/view.detail.php
+++ b/modules/Employees/views/view.detail.php
@@ -128,7 +128,11 @@ EOHTML;
             $this->ss->assign('DELETE_WARNING', $deleteWarning);
         }
         $this->ss->assign('DISPLAY_DELETE', $showDeleteButton);
-
+        if (!$this->bean->ACLAccess('detail')) {
+            $noaccessView = new ViewNoaccess();
+            $noaccessView->display();
+            sugar_die('');
+        }
         parent::display();
     }
 }

--- a/modules/Employees/views/view.edit.php
+++ b/modules/Employees/views/view.edit.php
@@ -95,7 +95,11 @@ class EmployeesViewEdit extends ViewEdit
                 $this->ss->assign('DEPT_READONLY', $this->bean->department);
             }
         }
-
+        if (!$this->bean->ACLAccess('view') || !$this->bean->ACLAccess('save')) {
+            $noaccessView = new ViewNoaccess();
+            $noaccessView->display();
+            sugar_die('');
+        }
         parent::display();
     }
 }

--- a/modules/Employees/views/view.list.php
+++ b/modules/Employees/views/view.list.php
@@ -53,6 +53,11 @@ class EmployeesViewList extends ViewList
         if (!$GLOBALS['current_user']->isAdminForModule('Users')) {
             $this->lv->multiSelect = false;
         }
+        if (!$this->bean->ACLAccess('view')) {
+            $noaccessView = new ViewNoaccess();
+            $noaccessView->display();
+            sugar_die('');
+        }
     }
 
     /**


### PR DESCRIPTION
## Description
This pull request avoids the use of the Employee module unless you log in with an admin user or your role assigned allows it.

## Motivation and Context
In order to protect the data and privacy of any employee we should not allow any user to have access of the module. Before, even if you block the module for a specific role, you could still enter by URL or in the tab menu

## How To Test This
Log in with a user with a role assigned that does not have access to the Employee module. You would not be able to see it by URL or in the tab menu (Under your profile).