### PR TITLE
Added xdebug configuration to dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -98,3 +98,12 @@ RUN if [ ! -f /var/www/html/suitecrm/Api/V8/OAuth2/private.key ]; then \
 COPY ./.devcontainer/config/000-default.conf /etc/apache2/sites-available/000-default.conf
 COPY ./.devcontainer/config/.htaccess /var/www/html/.htaccess
 RUN a2enmod rewrite
+
+# Adds xDebug configuration
+RUN echo "zend_extension=xdebug.so" >> /etc/php/7.4/mods-available/xdebug.ini && \
+    echo "xdebug.mode=debug" >> /etc/php/7.4/mods-available/xdebug.ini && \
+    echo "xdebug.start_with_request=trigger" >> /etc/php/7.4/mods-available/xdebug.ini && \
+    echo "xdebug.client_port=9003" >> /etc/php/7.4/mods-available/xdebug.ini && \
+    echo "xdebug.discover_client_host=true" >> /etc/php/7.4/mods-available/xdebug.ini && \
+    echo "xdebug.idekey=VSCODE" >> /etc/php/7.4/mods-available/xdebug.ini
+    

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,49 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+
+  // Move this file to the .vscode folder to be able to use xdebugger
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Listen for Xdebug",
+      "type": "php",
+      "request": "launch",
+      "port": 9003,
+    },
+    {
+      "name": "Launch currently open script",
+      "type": "php",
+      "request": "launch",
+      "program": "${file}",
+      "args": ["--install", "CustomInvoices"],
+      "cwd": "${fileDirname}",
+      "port": 0,
+      "runtimeArgs": ["-dxdebug.start_with_request=yes"],
+      "env": {
+        "XDEBUG_MODE": "debug,develop",
+        "XDEBUG_CONFIG": "client_port=${port}"
+      }
+    },
+    {
+      "name": "Launch Built-in web server",
+      "type": "php",
+      "request": "launch",
+      "runtimeArgs": [
+        "-dxdebug.mode=debug",
+        "-dxdebug.start_with_request=yes",
+        "-S",
+        "localhost:0"
+      ],
+      "program": "",
+      "cwd": "${workspaceRoot}",
+      "port": 9003,
+      "serverReadyAction": {
+        "pattern": "Development Server \\(http://localhost:([0-9]+)\\) started",
+        "uriFormat": "http://localhost:%s",
+        "action": "openExternally"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Description
Updated the `devcontainer` configuration to include Xdebug setup. Previously, the devcontainer lacked Xdebug configuration, which hindered debugging capabilities during development. This change ensures developers can use Xdebug for improved code inspection and troubleshooting.

## Motivation and Context
This update is required to enable Xdebug for development purposes within the devcontainer. Without this configuration, developers cannot utilize debugging tools effectively, leading to slower debugging processes and reduced productivity.

## How To Test This
1. Open the project in a devcontainer after pulling the updated configuration.
2. Verify that Xdebug is installed and configured correctly:
   - Check the Xdebug version using `php -v` in the terminal.
   - Ensure Xdebug is active and can connect to an IDE for remote debugging.
3. Set up a breakpoint in your IDE and trigger the application to verify that Xdebug properly halts execution.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.  
  *(N/A: This change does not affect documentation as it is an internal development tool update.)*
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
